### PR TITLE
backstage: Upgrade react to 18 on branch smartshift-smith-m-1690298774

### DIFF
--- a/microsite/package.json
+++ b/microsite/package.json
@@ -36,9 +36,9 @@
     "clsx": "^1.1.1",
     "docusaurus-plugin-sass": "^0.2.3",
     "luxon": "^3.0.0",
-    "prism-react-renderer": "^1.3.5",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "prism-react-renderer": "latest",
+    "react": "18",
+    "react-dom": "latest",
     "sass": "^1.57.1",
     "swc-loader": "^0.2.3"
   }

--- a/microsite/src/components/simpleCard/simpleCard.tsx
+++ b/microsite/src/components/simpleCard/simpleCard.tsx
@@ -4,14 +4,16 @@ export interface ICardData {
   header: React.ReactNode;
   body: React.ReactNode;
   footer: React.ReactNode;
+  children?: React.ReactNode;
 }
 
-export const SimpleCard = ({ header, body, footer }: ICardData) => (
+export const SimpleCard = ({ header, body, footer, children }: ICardData) => (
   <div className="card">
     <div className="card__header">{header}</div>
 
     <div className="card__body">{body}</div>
 
     <div className="card__footer">{footer}</div>
+    {children}
   </div>
 );

--- a/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
+++ b/microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx';
-import React, { useEffect, useState } from 'react';
+import React, { useInsertionEffect, useState } from 'react';
 
 import hubSpotStyles from './hubSpotNewAdoptersForm.module.scss';
 
 export const HubSpotNewAdoptersForm = () => {
   const [isClosed, setClosed] = useState(true);
 
-  useEffect(() => {
+  useInsertionEffect(() => {
     const script = document.createElement('script');
     script.src = 'https://js.hsforms.net/forms/v2.js';
     document.body.appendChild(script);

--- a/microsite/src/pages/on-demand/_onDemandCard.tsx
+++ b/microsite/src/pages/on-demand/_onDemandCard.tsx
@@ -1,7 +1,3 @@
-import Link from '@docusaurus/Link';
-import { SimpleCard } from '@site/src/components/simpleCard/simpleCard';
-import React from 'react';
-
 export interface IOnDemandData {
   title: string;
   category: string;
@@ -11,56 +7,5 @@ export interface IOnDemandData {
   youtubeImgUrl: string;
   rsvpUrl: string;
   eventUrl: string;
+  children?: React.ReactNode;
 }
-
-export const OnDemandCard = ({
-  title,
-  category,
-  description,
-  date,
-  youtubeUrl,
-  youtubeImgUrl,
-  rsvpUrl,
-  eventUrl,
-}: IOnDemandData) => (
-  <SimpleCard
-    header={
-      <>
-        <h3>{title}</h3>
-
-        <p className="PluginCardAuthor">on {date}</p>
-
-        <span className="badge badge--primary">{category}</span>
-
-        <img src={youtubeImgUrl} alt={title} />
-      </>
-    }
-    body={<p>{description}</p>}
-    footer={
-      category.toLowerCase() === 'upcoming' ? (
-        <>
-          <Link
-            to={eventUrl}
-            className="button button--outline button--sm button--primary"
-          >
-            Event page
-          </Link>
-
-          <Link
-            to={rsvpUrl}
-            className="button button--outline button--sm button--primary"
-          >
-            Remind me
-          </Link>
-        </>
-      ) : (
-        <Link
-          to={youtubeUrl}
-          className="button button--outline button--primary button--block"
-        >
-          Watch on YouTube
-        </Link>
-      )
-    }
-  />
-);

--- a/microsite/src/pages/plugins/_pluginCard.tsx
+++ b/microsite/src/pages/plugins/_pluginCard.tsx
@@ -14,6 +14,7 @@ export interface IPluginData {
   addedDate: string;
   isNew: boolean;
   order?: number;
+  children?: React.ReactNode;
 }
 
 const defaultIconUrl = 'img/logo-gradient-on-dark.svg';

--- a/microsite/yarn.lock
+++ b/microsite/yarn.lock
@@ -3006,6 +3006,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prismjs@npm:^1.26.0":
+  version: 1.26.0
+  resolution: "@types/prismjs@npm:1.26.0"
+  checksum: cd5e7a6214c1f4213ec512a5fcf6d8fe37a56b813fc57ac95b5ff5ee074742bfdbd2f2730d9fd985205bf4586728e09baa97023f739e5aa1c9735a7c1ecbd11a
+  languageName: node
+  linkType: hard
+
 "@types/prop-types@npm:*":
   version: 15.7.5
   resolution: "@types/prop-types@npm:15.7.5"
@@ -3766,9 +3773,9 @@ __metadata:
     js-yaml: ^4.1.0
     luxon: ^3.0.0
     prettier: ^2.6.2
-    prism-react-renderer: ^1.3.5
-    react: ^17.0.2
-    react-dom: ^17.0.2
+    prism-react-renderer: latest
+    react: 18
+    react-dom: latest
     sass: ^1.57.1
     swc-loader: ^0.2.3
     typescript: ^4.9.4
@@ -9450,6 +9457,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"prism-react-renderer@npm:latest":
+  version: 2.0.6
+  resolution: "prism-react-renderer@npm:2.0.6"
+  dependencies:
+    "@types/prismjs": ^1.26.0
+    clsx: ^1.2.1
+  peerDependencies:
+    react: ">=16.0.0"
+  checksum: d2202b79ddf01d308da3ba2f7f31a852fb0fb2e0290575d44e719af4c1d91fa913d04eb480fa3ba03e2d35d745ae806904270ffad00770511ec8bd80db67cb24
+  languageName: node
+  linkType: hard
+
 "prismjs@npm:^1.29.0":
   version: 1.29.0
   resolution: "prismjs@npm:1.29.0"
@@ -9690,16 +9709,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:latest":
+  version: 18.2.0
+  resolution: "react-dom@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-    scheduler: ^0.20.2
+    scheduler: ^0.23.0
   peerDependencies:
-    react: 17.0.2
-  checksum: 1c1eaa3bca7c7228d24b70932e3d7c99e70d1d04e13bb0843bbf321582bc25d7961d6b8a6978a58a598af2af496d1cedcfb1bf65f6b0960a0a8161cb8dab743c
+    react: ^18.2.0
+  checksum: 7d323310bea3a91be2965f9468d552f201b1c27891e45ddc2d6b8f717680c95a75ae0bc1e3f5cf41472446a2589a75aed4483aee8169287909fcd59ad149e8cc
   languageName: node
   linkType: hard
 
@@ -9835,13 +9853,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^17.0.2":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:18":
+  version: 18.2.0
+  resolution: "react@npm:18.2.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: b254cc17ce3011788330f7bbf383ab653c6848902d7936a87b09d835d091e3f295f7e9dd1597c6daac5dc80f90e778c8230218ba8ad599f74adcc11e33b9d61b
+  checksum: 88e38092da8839b830cda6feef2e8505dec8ace60579e46aa5490fc3dc9bba0bd50336507dc166f43e3afc1c42939c09fe33b25fae889d6f402721dcd78fca1b
   languageName: node
   linkType: hard
 
@@ -10320,13 +10337,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:^0.23.0":
+  version: 0.23.0
+  resolution: "scheduler@npm:0.23.0"
   dependencies:
     loose-envify: ^1.1.0
-    object-assign: ^4.1.1
-  checksum: c4b35cf967c8f0d3e65753252d0f260271f81a81e427241295c5a7b783abf4ea9e905f22f815ab66676f5313be0a25f47be582254db8f9241b259213e999b8fc
+  checksum: d79192eeaa12abef860c195ea45d37cbf2bbf5f66e3c4dcd16f54a7da53b17788a70d109ee3d3dde1a0fd50e6a8fc171f4300356c5aee4fc0171de526bf35f8a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# backstage
## Tasks
### New APIs for Libraries
In the React 18 Working Group we worked with library maintainers to create new APIs needed to support concurrent rendering for use cases specific to their use case in areas like styles, and external stores.

#### Instructions
- Use 'useInsertionEffect' for CSS-in-JS libraries to address performance issues of injecting styles in render
    - microsite/src/pages/home/_hubSpotNewAdoptersForm.tsx
### Update TypeScript definitions
If your project uses TypeScript, you will need to update your @types/react and @types/react-dom dependencies to the latest versions.

#### Instructions
- Explicitly list the 'children' prop when defining props
    - microsite/src/components/simpleCard/simpleCard.tsx
    - microsite/src/pages/on-demand/_onDemandCard.tsx
    - microsite/src/pages/plugins/_pluginCard.tsx
### Upgrade repo
npm upgrade

#### Instructions
- Upgrade repo library
    - migrations/backstage/backstage/backstage/microsite/package.json
    - migrations/backstage/backstage/backstage/microsite/yarn.lock

## Errors

### Update TypeScript definitions
If your project uses TypeScript, you will need to update your @types/react and @types/react-dom dependencies to the latest versions.

#### Instructions
- Explicitly list the 'children' prop when defining props
    - migrations/backstage/backstage/backstage/microsite/src/pages/demos/index.tsx: migrations/backstage/backstage/backstage/microsite/src/pages/demos/index.tsx for task: Update TypeScript definitions, step: Explicitly list the 'children' prop when defining props exceeds 2000 tokens and not currently supported. 
